### PR TITLE
#include <windows.h>

### DIFF
--- a/Client/game/scripting.h
+++ b/Client/game/scripting.h
@@ -7,7 +7,7 @@
 // License: Public Domain (Taken from spookie's speedo mod)
 //
 //----------------------------------------------------------
-
+#include <windows.h>
 #pragma once
 
 #define MAX_SCRIPT_VARS	16	// Size of our variable saving array


### PR DESCRIPTION
it must be added to declare DWORD and BYTE